### PR TITLE
pr: [Nightly Fix] [BUG] - Fix three security and validation bugs in UploaderController

### DIFF
--- a/app/Http/Controllers/UploaderController.php
+++ b/app/Http/Controllers/UploaderController.php
@@ -35,7 +35,10 @@ class UploaderController extends Controller
         $ticketId = $this->resolveTicketId($request);
         $person = $this->resolvePerson($ticketId, $request);
 
-        $this->checkPermissionToUploadFile($person);
+        $permissionResponse = $this->checkPermissionToUploadFile($person);
+        if ($permissionResponse) {
+            return $permissionResponse;
+        }
 
         try {
             $uploadedFiles = UploadService::handleTempFileUpload($request->files());
@@ -76,8 +79,13 @@ class UploaderController extends Controller
 
     private function resolveTicketId($request)
     {
-        $ticketId = $request->getSafe('ticket_id', 'intval');
-        return $ticketId == 'undefined' ? null : $ticketId;
+        $ticketId = $request->get('ticket_id');
+        if ($ticketId === 'undefined' || $ticketId === null || $ticketId === '') {
+            return null;
+        }
+
+        $ticketId = intval($ticketId);
+        return $ticketId > 0 ? $ticketId : null;
     }
 
     private function resolvePerson($ticketId, Request $request)
@@ -183,7 +191,7 @@ class UploaderController extends Controller
 
     private function isValidImageType($image)
     {
-        $imageType = $image['image']->getClientOriginalExtension();
+        $imageType = strtolower($image['image']->getClientOriginalExtension());
         $supportedTypes = ['gif', 'ief', 'jpeg', 'webp', 'pjpeg', 'ktx', 'png'];
 
         if (! in_array($imageType, $supportedTypes)) {


### PR DESCRIPTION
## What
Three related bugs in `UploaderController`:
1. `checkPermissionToUploadFile()` return value was silently ignored — uploads proceeded even when permission was denied
2. `resolveTicketId()` used `getSafe(..., 'intval')` so the string `"undefined"` became `0`, associating orphan uploads with ticket #0
3. `isValidImageType()` compared extensions case-sensitively — `JPG`, `PNG`, `JPEG` uploads were incorrectly rejected

## Why
1. **Permission bypass**: unauthorized users reaching the endpoint could upload files regardless of the permission check result
2. **Integer coercion**: `intval("undefined") === 0` in PHP, so uploads without a ticket context were silently attached to ticket ID 0 instead of null
3. **Case sensitivity**: macOS/Windows clients routinely send uppercase extensions; those uploads failed with 'invalid image type' for perfectly valid files

## Fix
1. Capture return value of `checkPermissionToUploadFile()` and return immediately if truthy (error response)
2. Read `ticket_id` as raw string, explicitly check for `"undefined"`/null/empty before `intval()`, return `null` for 0 after cast
3. Wrap `getClientOriginalExtension()` with `strtolower()` before comparison

## Confidence
98% — logic is straightforward; `php -l` passes; all three are clearly wrong behaviors