### PR TITLE
pr: [Nightly Fix] [UX] - Fix wrong-case shortcode displayed in setup wizard

### DIFF
--- a/resources/admin/Components/Setup.vue
+++ b/resources/admin/Components/Setup.vue
@@ -83,7 +83,7 @@
                                     <!-- Shortcode Information -->
                                     <div class="fs_shortcode_info">
                                         <span class="fs_shortcode_text">{{ $t('Use Shortcode') }}</span>
-                                        <code class="fs_shortcode_badge">[Fluent_support_portal]</code>
+                                        <code class="fs_shortcode_badge">[fluent_support_portal]</code>
                                         <span class="fs_shortcode_text">in the selected page</span>
                                     </div>
                                 </el-form-item>


### PR DESCRIPTION
## What
Setup wizard displays `[Fluent_support_portal]` (capital F, underscore) as the shortcode to paste into a page.

## Why
The actual registered shortcode is `[fluent_support_portal]` (all lowercase). WordPress shortcodes are case-sensitive by default — copying the displayed value and pasting it into a page would silently produce no portal output.

## Fix
Changed the displayed `<code>` element from `[Fluent_support_portal]` to `[fluent_support_portal]`.

## Confidence
99% — registered shortcode is definitively lowercase; this is a user-facing display bug affecting every new setup