### PR TITLE
pr: [Nightly Fix] [DX] - Fix typo in FluentCRM install route (intsall → install)

### DIFF
--- a/app/Http/Routes/api.php
+++ b/app/Http/Routes/api.php
@@ -119,7 +119,9 @@ $router->prefix('settings')->withPolicy('AdminSettingsPolicy')->group(function (
     $router->get('/integration-statuses', 'SettingsController@integrationStatuses');
 
     $router->get('/fluentcrm-settings', 'SettingsController@getFluentCRMSettings');
+    // Backward-compatible typo route.
     $router->post('/intsall-fluentcrm', 'SettingsController@installFluentCRM');
+    $router->post('/install-fluentcrm', 'SettingsController@installFluentCRM');
 
     // Upload Settings
     $router->get('/remote-upload-settings', 'SettingsController@getRemoteUploadSettings');
@@ -258,4 +260,3 @@ $router->prefix('ticket_importer')->withPolicy('AdminSettingsPolicy')->group(fun
 
 $router->post('ticket_image_upload', 'UploaderController@uploadImage')
     ->withPolicy('AgentTicketPolicy');
-

--- a/resources/admin/Modules/Settings/FluentCRMIntegration.vue
+++ b/resources/admin/Modules/Settings/FluentCRMIntegration.vue
@@ -131,7 +131,7 @@ export default {
         },
         installFluentCRM() {
             this.installing = true;
-            this.$post('settings/intsall-fluentcrm')
+            this.$post('settings/install-fluentcrm')
                 .then(response => {
                     this.$notify({
                         type: 'success',


### PR DESCRIPTION
## What
Both the REST API route definition and the Vue frontend call use `intsall-fluentcrm` (typo) instead of `install-fluentcrm`.

## Why
The typo is self-consistent so it works today, but any external integration, Pro add-on, or future code using the correct spelling would silently 404. It also creates confusion during code review and onboarding.

## Fix
- Added correctly-spelled route `POST /install-fluentcrm` → same handler (`SettingsController@installFluentCRM`)
- Kept the old typo route with a backward-compatibility comment so existing callers keep working
- Updated `FluentCRMIntegration.vue` to call the correct path

## Confidence
97% — verified both sides reference the same typo; route addition is purely additive