### PR TITLE
pr: [Nightly Fix] [TYPO] - Add correct $prompt alias alongside legacy $promt typo in portal.js

### DIFF
--- a/resources/customer_portal/portal.js
+++ b/resources/customer_portal/portal.js
@@ -28,6 +28,8 @@ app.use(ElLoading);
 
 app.config.globalProperties.$notify = ElNotification;
 app.config.globalProperties.$confirm = ElMessageBox.confirm;
+app.config.globalProperties.$prompt = ElMessageBox.prompt;
+// Backward compatibility for legacy references.
 app.config.globalProperties.$promt = ElMessageBox.prompt;
 app.config.globalProperties.$messageBox = ElMessageBox;
 


### PR DESCRIPTION
## What
Customer portal registers `$promt` (typo) instead of `$prompt` as the Vue global property alias for `ElMessageBox.prompt`.

## Why
Any developer writing new portal components would naturally type `this.$prompt(...)` and get `undefined`, then need to discover the typo by reading source. Inconsistent with standard naming conventions across the rest of the app.

## Fix
Added `app.config.globalProperties.$prompt = ElMessageBox.prompt` alongside the existing `$promt` alias. The typo alias is kept with a comment for backward compatibility with any components already using it. Purely additive change.

## Confidence
96% — additive only; zero risk of breaking existing code