### PR TITLE
[Nightly Fix] Security - Verify Opt-In Request

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -442,9 +442,7 @@ class SettingsController extends Controller
 
         $url = add_query_arg($data, 'https://wpmanageninja.com/');
 
-        wp_remote_post($url, [
-            'sslverify' => false
-        ]);
+        wp_remote_post($url);
     }
 
     /**


### PR DESCRIPTION
## What
The setup opt-in request in SettingsController disabled TLS certificate verification for the outbound HTTPS request to wpmanageninja.com.

## Why
Disabling certificate verification weakens transport security and makes the request vulnerable to MITM interception.

## Fix
Removed the explicit `sslverify => false` override so WordPress uses its default certificate verification behavior.

## Confidence
High. This is a narrow security hardening change on a standard `wp_remote_post()` call and does not alter request payloads or control flow.