### PR TITLE
[Nightly Fix] Security - Verify Remote Attachment Fetch

### DIFF
--- a/app/Services/Includes/UploadService.php
+++ b/app/Services/Includes/UploadService.php
@@ -121,7 +121,6 @@ class UploadService
     public function requestContent($contentUrl, $acceptedMimes = [])
     {
         $response = wp_remote_request($contentUrl, [
-            'sslverify' => false,
             'method'    => 'GET',
             'timeout'   => 30
         ]);


### PR DESCRIPTION
## What
The remote attachment fetch path in UploadService disabled TLS certificate verification for outbound HTTPS requests.

## Why
That weakens transport security when downloading remote attachment content and exposes the request to certificate spoofing risks.

## Fix
Removed the explicit `sslverify => false` override so WordPress performs normal certificate verification during remote fetches.

## Confidence
High. This is a narrow security hardening change on the existing `wp_remote_request()` call and preserves the request method, timeout, and response handling.