### PR TITLE
[Nightly Fix] Security - Verify Maintenance Request

### DIFF
--- a/app/Services/Integrations/Maintenance.php
+++ b/app/Services/Integrations/Maintenance.php
@@ -16,7 +16,6 @@ class Maintenance
             'body'      => [
                 'payload' => $this->getData()
             ],
-            'sslverify' => false,
             'cookies'   => []
         ]);
 


### PR DESCRIPTION
## What
The maintenance telemetry request explicitly disabled TLS certificate verification.

## Why
That weakens HTTPS transport security for the maintenance payload and is unnecessary for a normal WordPress remote request.

## Fix
Removed the `sslverify => false` override so WordPress uses its default certificate validation.

## Confidence
High. The change is isolated to the transport options on a single `wp_remote_post()` call and does not change the payload or scheduling logic.