### PR TITLE
[Nightly Fix] Security - Verify Integration Requests

### DIFF
--- a/app/Services/Integrations/NotificationIntegrationBase.php
+++ b/app/Services/Integrations/NotificationIntegrationBase.php
@@ -57,7 +57,6 @@ abstract class NotificationIntegrationBase
     public function sendRequest($url, $params = [], $method = 'GET', $extraHeaders = [])
     {
         $request = wp_remote_request($url, [
-            'sslverify' => false,
             'method'    => $method,
             'body'      => $params,
             'headers'   => $extraHeaders


### PR DESCRIPTION
## What
Notification integration requests explicitly disabled TLS certificate verification in the shared request helper.

## Why
That weakens HTTPS transport security for every integration built on this helper.

## Fix
Removed the `sslverify => false` override so WordPress validates certificates normally for integration requests.

## Confidence
High. This is a transport-only hardening change in the shared request helper and does not alter request bodies, methods, or response parsing.