### PR TITLE
[Nightly Fix] Null Safety - Guard Empty Integration Request

### DIFF
--- a/app/Services/Integrations/NotificationIntegrationBase.php
+++ b/app/Services/Integrations/NotificationIntegrationBase.php
@@ -66,7 +66,7 @@ abstract class NotificationIntegrationBase
         if (is_wp_error($request)) {
             return new \WP_Error($request->get_error_code(), $request->get_error_message());
         } else if (!$request) {
-            return new \WP_Error(423, __('API Request Error', 'fluent-support'), $request->get_error_data());
+            return new \WP_Error(423, __('API Request Error', 'fluent-support'));
         }
 
         $code = wp_remote_retrieve_response_code($request);


### PR DESCRIPTION
## What
The shared notification integration request helper treated a falsey HTTP response as an error, but then tried to call `get_error_data()` on that falsey value.

## Why
If WordPress returns a falsey non-object response, the current code can fatally error while building the fallback `WP_Error`.

## Fix
Removed the invalid method call and now return a plain `WP_Error` for the falsey-response path.

## Confidence
High. The bug is self-contained and the fix only changes the fallback error construction for an already-failed request.