### PR TITLE
[Nightly Fix] Bug - Return Upload Permission Errors

### DIFF
--- a/app/Http/Controllers/UploaderController.php
+++ b/app/Http/Controllers/UploaderController.php
@@ -35,7 +35,10 @@ class UploaderController extends Controller
         $ticketId = $this->resolveTicketId($request);
         $person = $this->resolvePerson($ticketId, $request);
 
-        $this->checkPermissionToUploadFile($person);
+        $permissionError = $this->checkPermissionToUploadFile($person);
+        if ($permissionError) {
+            return $permissionError;
+        }
 
         try {
             $uploadedFiles = UploadService::handleTempFileUpload($request->files());
@@ -118,6 +121,8 @@ class UploaderController extends Controller
                 ]);
             }
         }
+
+        return null;
     }
 
     private function createAttachmentRecords($uploadedFiles, $ticketId, $person, $imageType)


### PR DESCRIPTION
## What
`uploadTicketFiles()` called `checkPermissionToUploadFile()` but ignored the error response it returned.

## Why
When the current user is not allowed to upload, the controller still continues into the upload flow instead of stopping immediately. That can lead to unintended processing and later null dereferences.

## Fix
Capture the permission-check result and return it immediately when an error is produced.

## Confidence
High. The control-flow bug is explicit in the method and the fix only short-circuits on the existing error path.