### PR TITLE
[Nightly Fix] Bug - Return Invalid Image Errors

### DIFF
--- a/app/Http/Controllers/UploaderController.php
+++ b/app/Http/Controllers/UploaderController.php
@@ -165,7 +165,10 @@ class UploaderController extends Controller
     {
         $images = $request->files();
         $ticketId = $this->resolveTicketId($request);
-        $this->isValidImageType($images);
+        $imageTypeError = $this->isValidImageType($images);
+        if ($imageTypeError) {
+            return $imageTypeError;
+        }
 
         try {
             $uploadedFiles = UploadService::handleUploadToLocal($ticketId, $images);
@@ -191,5 +194,7 @@ class UploaderController extends Controller
                 'message' => 'Invalid image file.',
             ]);
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
## What
`uploadImage()` called `isValidImageType()` but ignored the error response from invalid file types.

## Why
Invalid image uploads currently continue into the local upload flow even after the controller has already built an error response.

## Fix
Return immediately when image validation fails, and make the validator explicitly return `null` on success.

## Confidence
High. This is a straightforward control-flow fix on the existing invalid-image path.