### PR TITLE
[Nightly Fix] Bug - Guard Undefined Ticket IDs

### DIFF
--- a/app/Http/Controllers/UploaderController.php
+++ b/app/Http/Controllers/UploaderController.php
@@ -76,8 +76,12 @@ class UploaderController extends Controller
 
     private function resolveTicketId($request)
     {
-        $ticketId = $request->getSafe('ticket_id', 'intval');
-        return $ticketId == 'undefined' ? null : $ticketId;
+        $rawTicketId = $request->getSafe('ticket_id', 'sanitize_text_field');
+        if ($rawTicketId === 'undefined' || $rawTicketId === '') {
+            return null;
+        }
+
+        return intval($rawTicketId);
     }
 
     private function resolvePerson($ticketId, Request $request)


### PR DESCRIPTION
## What
`resolveTicketId()` sanitizes `ticket_id` with `intval()` and then compares the integer result to the string `"undefined"`.

## Why
That comparison can never succeed, so requests that send the literal `undefined` value end up being normalized to `0` instead of `null`.

## Fix
Read the raw `ticket_id` first, explicitly treat `undefined` and empty values as missing, and only cast to `int` after that check.

## Confidence
High. The current comparison is dead code, and the replacement keeps the existing integer behavior for valid ticket IDs.