### PR TITLE
[Nightly Fix] Bug - Return Portal Settings

### DIFF
--- a/app/Services/ProfileInfoService.php
+++ b/app/Services/ProfileInfoService.php
@@ -65,7 +65,7 @@ class ProfileInfoService
     public function me( $settings, $withPortalSettings )
     {
         if ( $withPortalSettings ) {
-            $this->portalSettings(  $settings );
+            $settings = $this->portalSettings($settings);
         }
 
         return $settings;


### PR DESCRIPTION
## What
`ProfileInfoService::me()` calls `portalSettings()` when `with_portal_settings` is requested, but it discards the returned array.

## Why
The API response silently omits `portal_settings` even when the caller explicitly asks for them.

## Fix
Assign the returned settings array back before returning the final payload.

## Confidence
High. The bug is a direct lost-assignment issue, and the fix only preserves the existing return value from `portalSettings()`.