### PR TITLE
pr: [Nightly Fix] - Bug - Fix reCAPTCHA Duplicate Detection

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -295,8 +295,9 @@ class SettingsController extends Controller
         ];
 
         $previousValue = Meta::where('object_type', '_fs_recaptcha_settings')->first();
+        $savedSettings = $previousValue ? Helper::safeUnserialize($previousValue->value, []) : [];
 
-        if ($previousValue === $reCaptchaData) {
+        if ($savedSettings === $reCaptchaData) {
             return $this->sendError([
                 'message' => __('Your recaptcha details are already saved.', 'fluent-support'),
             ]);


### PR DESCRIPTION
Fixes logic bug where saved reCAPTCHA settings were compared as a Meta object vs array, so the duplicate-save check never triggered. Deserializes saved value before comparison.