### PR TITLE
pr: [Nightly Fix] - Bug - Stop Unauthorized Upload Processing

### DIFF
--- a/app/Http/Controllers/UploaderController.php
+++ b/app/Http/Controllers/UploaderController.php
@@ -35,7 +35,9 @@ class UploaderController extends Controller
         $ticketId = $this->resolveTicketId($request);
         $person = $this->resolvePerson($ticketId, $request);
 
-        $this->checkPermissionToUploadFile($person);
+        if ($permissionError = $this->checkPermissionToUploadFile($person)) {
+            return $permissionError;
+        }
 
         try {
             $uploadedFiles = UploadService::handleTempFileUpload($request->files());


### PR DESCRIPTION
Fixes missing early return in UploaderController — on permission failure the error payload was returned but execution continued into a null-person path. Added proper early return.