### PR TITLE
pr: [Nightly Fix] - Performance - Batch Portal Feedback Queries

### DIFF
--- a/app/Services/CustomerPortalService.php
+++ b/app/Services/CustomerPortalService.php
@@ -476,25 +476,39 @@ class CustomerPortalService
             ->latest('id')
             ->get();
 
+        $feedbackByResponseId = [];
+
+        if (defined('FLUENTSUPPORTPRO_PLUGIN_VERSION') && Helper::isAgentFeedbackEnabled()) {
+            $responseIds = [];
+
             foreach ($responses as $response) {
-                if (defined('FLUENTSUPPORTPRO_PLUGIN_VERSION') && Helper::isAgentFeedbackEnabled()) {
-                    $agentFeedback = Meta::where('object_id', $response->id)
-                        ->where('object_type', 'conversation_meta')
-                        ->where('key', 'agent_feedback_ratings')
-                        ->first();
+                $responseIds[] = $response->id;
+            }
 
-                    if ($agentFeedback) {
-                        $response->agent_feedback = $agentFeedback->value;
-                    }
-                }
+            if ($responseIds) {
+                $feedbackMeta = Meta::whereIn('object_id', $responseIds)
+                    ->where('object_type', 'conversation_meta')
+                    ->where('key', 'agent_feedback_ratings')
+                    ->get(['object_id', 'value']);
 
-                // translators: %s is the time duration (e.g., "2 hours", "3 days")
-                $response->human_date = sprintf(__('%s ago', 'fluent-support'), human_time_diff(strtotime($response->created_at), current_time('timestamp')));
-                $response->content = links_add_target(make_clickable($response->content));
-                if ($response->person) {
-                    $response->person->setHidden(['email']);
+                foreach ($feedbackMeta as $feedback) {
+                    $feedbackByResponseId[$feedback->object_id] = $feedback->value;
                 }
             }
+        }
+
+        foreach ($responses as $response) {
+            if (isset($feedbackByResponseId[$response->id])) {
+                $response->agent_feedback = $feedbackByResponseId[$response->id];
+            }
+
+            // translators: %s is the time duration (e.g., "2 hours", "3 days")
+            $response->human_date = sprintf(__('%s ago', 'fluent-support'), human_time_diff(strtotime($response->created_at), current_time('timestamp')));
+            $response->content = links_add_target(make_clickable($response->content));
+            if ($response->person) {
+                $response->person->setHidden(['email']);
+            }
+        }
 
         return $responses;
     }


### PR DESCRIPTION
Fixes N+1 query in CustomerPortalService response feedback meta fetching. Batches all meta lookups for responses into a single query.