### PR TITLE
- Adds pre/post render filters for ticket content

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -310,7 +310,22 @@ class TicketController extends Controller
 
             //Format response content
             foreach ($ticket->responses as $response) {
-                $response->content = links_add_target(make_clickable(wpautop($response->content, false)));
+                $responseContent = apply_filters(
+                    'fluent_support/response_content_before_render',
+                    $response->content,
+                    $response,
+                    $ticket
+                );
+
+                $responseContent = links_add_target(make_clickable(wpautop($responseContent, false)));
+
+                $response->content = apply_filters(
+                    'fluent_support/response_content_after_render',
+                    $responseContent,
+                    $response,
+                    $ticket
+                );
+
                 if (!empty($response->ccinfo)) {
                     $val = Helper::safeUnserialize($response->ccinfo->value);
                     if (isset($val['cc_email']) && !empty($val['cc_email'])) {
@@ -323,7 +338,19 @@ class TicketController extends Controller
                 }
             }
 
-            $ticket->content = links_add_target(make_clickable(wpautop($ticket->content, false)));
+            $ticketContent = apply_filters(
+                'fluent_support/ticket_content_before_render',
+                $ticket->content,
+                $ticket
+            );
+
+            $ticketContent = links_add_target(make_clickable(wpautop($ticketContent, false)));
+
+            $ticket->content = apply_filters(
+                'fluent_support/ticket_content_after_render',
+                $ticketContent,
+                $ticket
+            );
 
             //Get last activity by agent
             $ticket->live_activity = TicketHelper::getActivity($ticket->id, $agent->id);


### PR DESCRIPTION
# Add render-time filters for ticket and response content

## Summary

This change restores the Fluent Support content rendering extension points in the current `TicketController` implementation.

It adds four WordPress filters around the existing ticket and response content rendering pipeline:

- `fluent_support/response_content_before_render`
- `fluent_support/response_content_after_render`
- `fluent_support/ticket_content_before_render`
- `fluent_support/ticket_content_after_render`

## Why

These hooks let plugin/theme integrations customize ticket and response body content without overriding controller logic. This is useful for adding custom formatting, token replacement, embeds, redaction, link handling, or other site-specific rendering behavior while preserving Fluent Support's default `wpautop()`, `make_clickable()`, and `links_add_target()` processing.

## What changed

### Response content

Before each conversation response is rendered, the raw response content is passed through:

```php
apply_filters(
    'fluent_support/response_content_before_render',
    $response->content,
    $response,
    $ticket
);
```

After Fluent Support applies its normal formatting, the rendered response content is passed through:

```php
apply_filters(
    'fluent_support/response_content_after_render',
    $responseContent,
    $response,
    $ticket
);
```

### Ticket content

Before the ticket body is rendered, the raw ticket content is passed through:

```php
apply_filters(
    'fluent_support/ticket_content_before_render',
    $ticket->content,
    $ticket
);
```

After Fluent Support applies its normal formatting, the rendered ticket content is passed through:

```php
apply_filters(
    'fluent_support/ticket_content_after_render',
    $ticketContent,
    $ticket
);
```

## Backwards compatibility

No behavior changes occur unless a third-party integration registers one of these filters. Without callbacks, `apply_filters()` returns the original value and the controller continues to render content as before.

## Testing

- Ran PHP syntax check: `php -l TicketController.patched.php`
- Confirmed no syntax errors were detected.
- Verified the default content rendering pipeline still applies `wpautop()`, `make_clickable()`, and `links_add_target()`.